### PR TITLE
style(subnet): rename resources to this, add output descriptions, remove unused tags variable

### DIFF
--- a/modules/subnet/README.md
+++ b/modules/subnet/README.md
@@ -14,15 +14,14 @@
 | <a name="input_route_table_id"></a> [route\_table\_id](#input\_route\_table\_id) | The ID of the route table which should be associated with the subnet. | `string` | `null` | no |
 | <a name="input_service_delegation"></a> [service\_delegation](#input\_service\_delegation) | The name of service to delegate to. | `string` | `null` | no |
 | <a name="input_service_endpoints"></a> [service\_endpoints](#input\_service\_endpoints) | The list of Service endpoints to associate with the subnet. | `set(string)` | `[]` | no |
-| <a name="input_tags"></a> [tags](#input\_tags) | Optional tags for the resource group. | `map(any)` | `null` | no |
 | <a name="input_virtual_network_name"></a> [virtual\_network\_name](#input\_virtual\_network\_name) | Name of the virtual network. | `string` | n/a | yes |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| <a name="output_id"></a> [id](#output\_id) | n/a |
-| <a name="output_name"></a> [name](#output\_name) | n/a |
+| <a name="output_id"></a> [id](#output\_id) | The ID of the subnet. |
+| <a name="output_name"></a> [name](#output\_name) | The name of the subnet. |
 
 # Examples
 

--- a/modules/subnet/main.tf
+++ b/modules/subnet/main.tf
@@ -1,4 +1,4 @@
-resource "azurerm_subnet" "subnet" {
+resource "azurerm_subnet" "this" {
   name                 = var.name
   resource_group_name  = var.resource_group_name
   virtual_network_name = var.virtual_network_name
@@ -16,14 +16,14 @@ resource "azurerm_subnet" "subnet" {
   }
 }
 
-resource "azurerm_subnet_route_table_association" "route_table_association" {
+resource "azurerm_subnet_route_table_association" "this" {
   count          = var.route_table_id == null ? 0 : 1
-  subnet_id      = azurerm_subnet.subnet.id
+  subnet_id      = azurerm_subnet.this.id
   route_table_id = var.route_table_id
 }
 
-resource "azurerm_subnet_network_security_group_association" "nsg_association" {
+resource "azurerm_subnet_network_security_group_association" "this" {
   count                     = var.network_security_group_id == null ? 0 : 1
   network_security_group_id = var.network_security_group_id
-  subnet_id                 = azurerm_subnet.subnet.id
+  subnet_id                 = azurerm_subnet.this.id
 }

--- a/modules/subnet/outputs.tf
+++ b/modules/subnet/outputs.tf
@@ -1,7 +1,9 @@
 output "id" {
-  value = azurerm_subnet.subnet.id
+  description = "The ID of the subnet."
+  value       = azurerm_subnet.this.id
 }
 
 output "name" {
-  value = azurerm_subnet.subnet.name
+  description = "The name of the subnet."
+  value       = azurerm_subnet.this.name
 }

--- a/modules/subnet/variables.tf
+++ b/modules/subnet/variables.tf
@@ -46,9 +46,3 @@ variable "network_security_group_id" {
   description = "The ID of the network security group which should be associated with the subnet."
   default     = null
 }
-
-variable "tags" {
-  type        = map(any)
-  description = "Optional tags for the resource group."
-  default     = null
-}


### PR DESCRIPTION
## Summary

- **Rename** resource local names to `"this"` per convention (`azurerm_subnet.subnet` -> `azurerm_subnet.this`, etc.)
- **Add descriptions** to both outputs (`id`, `name`)
- **Remove** unused `tags` variable (`azurerm_subnet` does not support tags)

### Breaking Change
State resources will need to be moved if upgrading in-place (e.g., `terraform state mv azurerm_subnet.subnet azurerm_subnet.this`).